### PR TITLE
Upgrade to Airflow 1.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ It will return a command to login to ECR. Run that command to login.
 To build the image make sure to change the Account ID:
 ```bash
 aws_account_id=changeme
-./build-docker-image --repo ecr --aws-account-id ${aws_account_id} --region us-west-2 --version 0.0.4
+./build-docker-image --repo ecr --aws-account-id ${aws_account_id} --region us-west-2 --version 0.0.5
 ```
 
 #### Docker Hub
@@ -72,7 +72,7 @@ docker login
 
 To build the image:
 ```bash
-./build-docker-image --repo dockerhub --version 0.0.4
+./build-docker-image --repo dockerhub --version 0.0.5
 ```
 
 ### Postgres (RDS)

--- a/docker/airflow/Dockerfile
+++ b/docker/airflow/Dockerfile
@@ -1,4 +1,4 @@
-FROM puckel/docker-airflow:1.9.0-4
+FROM puckel/docker-airflow:1.10.0-2
 
 MAINTAINER 'Freckle IoT'
 


### PR DESCRIPTION
The following changes will be required:
- For Google Auth you have to change the Redirect URI from `https://<URL>/oauth2callback?next=%2Fadmin%2F`
to `https://<URL>/oauth2callback`
- For using the `EmailOperator` with Amazon SES, set `mime_charset='UTF-8'` because it does not like the default `us_ascii` value.
